### PR TITLE
Fizzle296

### DIFF
--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -308,10 +308,6 @@ app.registerExtension({
 					}
 				}
 
-				if (widget.type === "combo") {
-					addSeedControlWidget(this, widget, "randomize");
-				}
-
 				// When our value changes, update other widgets to reflect our changes
 				// e.g. so LoadImage shows correct image
 				const callback = widget.callback;

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -294,7 +294,7 @@ app.registerExtension({
 					// addSeedControlWidget(node, seed.widget, "randomize");
 
 					if (widget.type === "number") {
-						addSeedControlWidget(this, widget, "randomize");
+						addSeedControlWidget(this, widget, "fixed seed");
 					}
 				}
 

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -301,10 +301,11 @@ app.registerExtension({
 						widget = this.addWidget(type, widgetName /*"value"*/, null, () => { }, {});
 					}
 					
+					// addSeedControlWidget(node, seed.widget, "randomize");
 
-					// if (widget.type === "number") {
-					// 	addSeedControlWidget(this, this.widget, "randomize");
-					// }
+					if (widget.type === "number") {
+						addSeedControlWidget(this, widget, "randomize");
+					}
 				}
 
 				if (node?.widgets && widget) {

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -275,9 +275,7 @@ app.registerExtension({
                 }
 				*/
 				this.#createWidget(widget.config, theirNode, widget.name);
-				if (widget.name === "seed") {
-					addSeedControlWidget(this, this.widget, "randomize");
-				}
+				
 			}
 
 			#createWidget(inputData, node, widgetName) {
@@ -289,12 +287,25 @@ app.registerExtension({
 
 				let widget;
 				
-				if (type in ComfyWidgets) {
-					widget = (ComfyWidgets[type](this, widgetName/*"value*"*/, inputData, app) || {}).widget;
+				// ComfyWidgets allows a subtype of widgets which is defined by "<type>:<widgetName>"
+				// common example is "INT:seed"
+				// so let's check for those first
+				let combinedWidgetType = type + ":" + widgetName;
+				if (combinedWidgetType in ComfyWidgets) {
+					widget = (ComfyWidgets[combinedWidgetType](this, "value", inputData, app) || {}).widget;
 				} else {
-					widget = this.addWidget(type, widgetName /*"value"*/, null, () => { }, {});
+					// we did not find a subtype, so proceed with "<type>" only
+					if (type in ComfyWidgets) {
+						widget = (ComfyWidgets[type](this, widgetName/*"value*"*/, inputData, app) || {}).widget;
+					} else {
+						widget = this.addWidget(type, widgetName /*"value"*/, null, () => { }, {});
+					}
+					
+
+					// if (widget.type === "number") {
+					// 	addSeedControlWidget(this, this.widget, "randomize");
+					// }
 				}
-				
 
 				if (node?.widgets && widget) {
 

--- a/web/extensions/core/widgetInputs.js
+++ b/web/extensions/core/widgetInputs.js
@@ -284,7 +284,8 @@ app.registerExtension({
 				// so let's check for those first
 				let combinedWidgetType = type + ":" + widgetName;
 				if (combinedWidgetType in ComfyWidgets) {
-					widget = (ComfyWidgets[combinedWidgetType](this, "value", inputData, app) || {}).widget;
+					// widget = (ComfyWidgets[combinedWidgetType](this, "value", inputData, app) || {}).widget;
+					widget = (ComfyWidgets[combinedWidgetType](this, widgetName, inputData, app) || {}).widget;
 				} else {
 					// we did not find a subtype, so proceed with "<type>" only
 					if (type in ComfyWidgets) {
@@ -302,7 +303,7 @@ app.registerExtension({
 
 				if (node?.widgets && widget) {
 
-	const theirWidget = node.widgets.find((w) => w.name === widgetName);
+				const theirWidget = node.widgets.find((w) => w.name === widgetName);
 					if (theirWidget) {
 						widget.value = theirWidget.value;
 					}

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -59,7 +59,7 @@ function seedWidget(node, inputName, inputData) {
 	const seedControl = addSeedControlWidget(node, seed.widget, "randomize");
 
 	seed.widget.linkedWidgets = [seedControl];
-	return { widget: seed, seedControl };
+	return seed;
 }
 
 const MultilineSymbol = Symbol();

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -11,7 +11,7 @@ function getNumberDefaults(inputData, defaultStep) {
 }
 
 export function addSeedControlWidget(node, targetWidget, defaultValue = "randomize", values) {
-	const seedControl = node.addWidget("combo", "seed control after generating", "randomize", function (v) { }, {
+	const seedControl = node.addWidget("combo", "seed control after generating", defaultValue, function (v) { }, {
 		values: ["fixed seed", "increment", "decrement", "randomize"],
 		serialize: false, // Don't include this in prompt.
 	})

--- a/web/scripts/widgets.js
+++ b/web/scripts/widgets.js
@@ -12,7 +12,8 @@ function getNumberDefaults(inputData, defaultStep) {
 
 export function addSeedControlWidget(node, targetWidget, defaultValue = "randomize", values) {
 	const seedControl = node.addWidget("combo", "seed control after generating", "randomize", function (v) { }, {
-		values: ["fixed seed", "increment", "decrement", "randomize"]
+		values: ["fixed seed", "increment", "decrement", "randomize"],
+		serialize: false, // Don't include this in prompt.
 	})
 	seedControl.afterQueued = () => {
 


### PR DESCRIPTION
I think I am done with some fixes.

How it behaves now:
Seed widget plus all number widgets receive a seedControl when adding a primitive.
While testing it I didn't like that values like "steps" in the KSampler were autoset to randomize, so I changed the standard behaviour to:
1) Seed widget: randomize
2) other number widget: fixed seed


